### PR TITLE
수정: 소켓 통신 관련 오류 해결

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,7 +1,8 @@
-from fastapi  import APIRouter
+from fastapi     import APIRouter, Depends
 
-from app.api  import users, study_rooms
-from app.core import study_rooms_settings, user_settings
+from app.api     import users, study_rooms
+from app.core    import study_rooms_settings, user_settings
+from app.service import auth_token
 
 
 api_router = APIRouter()
@@ -10,8 +11,10 @@ api_router.include_router(
     prefix=user_settings.API_USER,
     tags=['users']
 )
+# TODO: 의존성 추가
 api_router.include_router(
     study_rooms.router,
     prefix=study_rooms_settings.API_STUDY_ROOM,
+    # dependencies=[Depends(auth_token),],
     tags=['study_rooms']
-) 
+)

--- a/app/api/study_rooms.py
+++ b/app/api/study_rooms.py
@@ -116,7 +116,7 @@ def update_study_room(room_id: str, room_info: StudyRoomsUpdate, db: Session = D
 
     except Exception as error:
         print(traceback.print_exc())
-        return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={'detail': f'server error: {detail}'})
+        return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={'detail': f'server error: {error}'})
 
 
 @router.delete(

--- a/app/main.py
+++ b/app/main.py
@@ -5,10 +5,12 @@ from fastapi     import FastAPI
 
 from app.api     import api_router
 from app.core    import common_settings
-# from app.service import sio
+from app.service import sio
 
 
 server  = FastAPI(title=common_settings.PROJECT_NAME)
+sio_app = socketio.ASGIApp(socketio_server=sio, other_asgi_app=server)
+server.add_websocket_route("/socket.io/", sio_app)
 server.include_router(api_router, prefix=common_settings.COMMON_API)
 
 

--- a/app/service/__init__.py
+++ b/app/service/__init__.py
@@ -1,1 +1,2 @@
+from app.service.auth    import auth_token
 from app.service.sockets import sio

--- a/app/service/sockets.py
+++ b/app/service/sockets.py
@@ -7,12 +7,11 @@ from app.crud               import study_rooms
 from app.database           import SessionLocal
 
 
-# TODO: server.mount 외에 소켓 route 통신 방법 
-
 db            = SessionLocal()
 sio           = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', debug=True)
 namespace_url = socket_settinngs.NAMESPACE_URL
 clients       = dict()
+
 
 
 @sio.event(namespace=namespace_url)


### PR DESCRIPTION
소켓 통신 관련된 부분 해결했습니다. 소켓 통신이 이뤄지는지 확인했고 관련해서 `stack overflow` 오류도 따로 발생하지 않는 것 확인했습니다.

의존성, `get_user` 관련해서 궁금한 점이 하나 있습니다. `APIRouter` 부분에 의존성 추가 해서 테스트 해보려고 했는데 `Header` 부분에 `Authorization` 추가를 따로 안 하고 테스트해보니까 이미지와 같은 오류를 반환했습니다. 제가 생각했을 때는 `Authorization` 이 비어있을 경우 토큰이 없으니 로그인이 안 된 사용자와 같은 오류를 반환해줘야 할 것 같은데 어차피 `get_user` 가 따로 있어서 해당 부분 이제 필요 없는 걸까요? 만약에 그렇다면 해당 부분 삭제 하도록 하겠습니다. 우선 주석 처리 해놓은 상태입니다.

<img width="780" alt="스크린샷 2021-05-21 오전 12 04 28" src="https://user-images.githubusercontent.com/63915557/119003341-9c313380-b9c8-11eb-84d0-4bb61c85824c.png">